### PR TITLE
Add an unsubscribe option

### DIFF
--- a/lib/mqtt-router.js
+++ b/lib/mqtt-router.js
@@ -99,6 +99,26 @@ var Router = function (mqttclient) {
   })
 
   /**
+   * Unsubscribe from a topic by clearing the handlers
+   *
+   * @param topic - MQTT topic (can have named params)
+   */
+  this.unsubscribe = function (topic) {
+    
+    // safety the topic as we do on subscribe
+    var safeTopic = this._stripParams(topic)
+    var routeOption = topic.replace(/\$/, '\\$').replace(/\+/, '').replace(/#/, '')
+
+    // find all matches
+    var endpoints = self._endpointMatches(safeTopic)
+    
+    // and empty the handlers, re-subscribe will only re-add handlers
+    endpoints.forEach(function resetEndpoint (endpoint) {
+      endpoint.reset()
+    })
+  }
+
+  /**
    * Subscribe to a topic using an optional route to break up the topic.
    *
    * @param topic - MQTT topic with named params


### PR DESCRIPTION
It's helpful to me to have an un-subscribe option since I am using promises to catch returns (think ping/pong) based on a user-action.  The user clicks a button and I use mqtt to find out if the service is awake before I send the request -- otherwise I handle the click differently.  I want to unsubscribe if the service is there or not there so that the next time around I can do it again.  The mqtt topic is different and auto-generated so I don't want to leave subscriptions hanging around.

and it would be a bother to have to